### PR TITLE
tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,7 @@ formatters:
   enable:
     - gci
     - gofmt
+    - gofumpt
   settings:
     gci:
       sections:

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,6 +18,8 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
+
 	cfg, err := configs.Init()
 	if err != nil {
 		logrus.Panicf("Configs error: %v\n", err)
@@ -47,14 +49,14 @@ func main() {
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
-		if err := server.Run(cfg, server.InitRoutes()); err != nil {
+		if err := server.Run(ctx, cfg, server.InitRoutes()); err != nil {
 			logrus.Panicf("HTTP Server error: %v\n", err)
 		}
 	}()
 
 	<-quit
 
-	if err := server.Shutdown(context.Background()); err != nil {
+	if err := server.Shutdown(ctx); err != nil {
 		logrus.Panicf("HTTP Server Shutdown error: %v\n", err)
 	}
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -56,10 +56,6 @@ func main() {
 
 	<-quit
 
-	if err := server.Shutdown(ctx); err != nil {
-		logrus.Panicf("HTTP Server Shutdown error: %v\n", err)
-	}
-
 	if err := psql.Close(); err != nil {
 		logrus.Panicf("PostgreSQL Close error: %v\n", err)
 	}

--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -26,7 +26,7 @@ func New(services *service.Service, userRepo *repository.UsersRepository) *Serve
 	}
 }
 
-func (s *Server) Run(cfg *configs.Config, handler http.Handler) error {
+func (s *Server) Run(ctx context.Context, cfg *configs.Config, handler http.Handler) error {
 	s.server = &http.Server{
 		Addr:           ":" + cfg.HTTP.Port,
 		Handler:        handler,

--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
-	"github.com/gorilla/mux"
 	configs "wallet-service/internal/config"
 	"wallet-service/internal/repository"
 	"wallet-service/internal/service"
+
+	"github.com/gorilla/mux"
 )
 
 const maxHeaderBytes = 1 << 20
@@ -39,6 +41,13 @@ func (s *Server) Run(ctx context.Context, cfg *configs.Config, handler http.Hand
 		return fmt.Errorf("failed to run the HTTP server: %w", err)
 	}
 
+	shutdownCtx, cancel := context.WithTimeout(ctx, 5 * time.Second)
+	defer cancel()
+
+	if err := s.Shutdown(shutdownCtx); err != nil {
+		return fmt.Errorf("failed to shutdown the HTTP server: %w", err)
+	}
+	
 	return nil
 }
 

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -1,7 +1,9 @@
 package tests
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 	configs "wallet-service/internal/config"
@@ -16,6 +18,7 @@ type IntegrationTestSuite struct {
 	suite.Suite
 
 	cfg         *configs.Config
+	cancel      context.CancelFunc
 	psql        *psql.PostgresDB
 	usersRepo   *repository.UsersRepository
 	walletsRepo *repository.WalletDB
@@ -25,6 +28,10 @@ type IntegrationTestSuite struct {
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s.cancel = cancel
+
 	var err error
 
 	s.cfg, err = configs.Init()
@@ -44,13 +51,13 @@ func (s *IntegrationTestSuite) SetupSuite() {
 
 	//nolint:testifylint
 	go func() {
-		err := s.server.Run(s.cfg, s.server.InitRoutes())
+		err := s.server.Run(ctx, s.cfg, s.server.InitRoutes())
 		s.Require().NoError(err)
 	}()
+
+	time.Sleep(time.Millisecond * 50)
 }
 
 func TestIntegrationSetupSuite(t *testing.T) {
-	t.Parallel()
-
 	suite.Run(t, new(IntegrationTestSuite))
 }

--- a/tests/wallets_test.go
+++ b/tests/wallets_test.go
@@ -1,0 +1,305 @@
+package tests
+
+import (
+	"context"
+	"net/http"
+	"wallet-service/internal/domain"
+
+	"github.com/google/uuid"
+)
+
+const walletPath = "/api/v1/wallets"
+
+var existingUser = domain.User{
+	Id: uuid.New(),
+}
+
+func (s *IntegrationTestSuite) TestCreateWallet() {
+	wallet := domain.Wallet{
+		Id:       uuid.New(),
+		UserId:   uuid.NewString(),
+		Name:     "wallet 1",
+		Currency: "USD",
+	}
+
+	s.Run("user not found", func() {
+		s.sendHTTPRequest(http.MethodGet, walletPath, http.StatusNotFound, &wallet, nil, existingUser)
+	})
+
+	s.Run("wallet successfully created", func() {
+		err := s.usersRepo.UpsertUser(context.Background(), existingUser)
+		s.Require().NoError(err)
+
+		wallet.Id = existingUser.Id
+
+		var createdWallet domain.Wallet
+
+		s.sendHTTPRequest(http.MethodPost, walletPath, http.StatusCreated, &wallet, &createdWallet, existingUser)
+
+		s.Require().Equal(wallet.Id, createdWallet.Id)
+		s.Require().Equal(wallet.UserId, createdWallet.UserId)
+		s.Require().Equal(wallet.Name, createdWallet.Name)
+		s.Require().Equal(0.0, createdWallet.Balance)
+		s.Require().Equal(wallet.Currency, createdWallet.Currency)
+	})
+
+	s.Run("wallet doesn't belong to the user", func() {
+		err := s.usersRepo.UpsertUser(context.Background(), existingUser)
+		s.Require().NoError(err)
+
+		otherUser := domain.User{
+			Id: uuid.New(),
+		}
+
+		err = s.usersRepo.UpsertUser(context.Background(), otherUser)
+		s.Require().NoError(err)
+
+		existingUser.Id = otherUser.Id
+
+		s.sendHTTPRequest(http.MethodGet, walletPath, http.StatusNotFound, &wallet, nil, existingUser)
+	})
+}
+
+func (s *IntegrationTestSuite) TestGetWallet() {
+	wallet := domain.Wallet{
+		Id: uuid.New(),
+		UserId: existingUser.Id.String(),
+		Name: "wallet 1",
+		Balance: 200.0,
+		Currency: "USD",
+	}
+
+	err := s.usersRepo.UpsertUser(context.Background(), existingUser)
+	s.Require().NoError(err)
+
+	var createdWallet domain.Wallet
+
+	s.sendHTTPRequest(http.MethodPost, walletPath, http.StatusCreated, &wallet, &createdWallet, existingUser)
+
+	s.Run("user not found", func() {		
+		s.sendHTTPRequest(http.MethodGet, walletPath, http.StatusNotFound, nil, nil, existingUser)
+	})
+
+	s.Run("get wallet successfully", func() {
+		walletId := uuid.UUID(createdWallet.Id).String()
+		fullWalletPath := walletPath + "/" + walletId
+
+		s.sendHTTPRequest(http.MethodGet, fullWalletPath, http.StatusOK, nil, &createdWallet, existingUser)
+
+		s.Require().Equal(wallet.Id, createdWallet.Id)
+		s.Require().Equal(wallet.UserId, createdWallet.UserId)
+		s.Require().Equal(wallet.Name, createdWallet.Name)
+		s.Require().Equal(wallet.Balance, createdWallet.Balance)
+		s.Require().Equal(wallet.Currency, createdWallet.Currency)
+	})
+
+	s.Run("wallet not found", func() {
+		walletId := uuid.New().String()
+		fullWalletPath := walletPath + "/" + walletId
+
+		s.sendHTTPRequest(http.MethodGet, fullWalletPath, http.StatusNotFound, nil, nil, existingUser)
+	})
+
+	s.Run("wallet doesn't belong to the user", func() {
+		otherUser := domain.User{
+			Id: uuid.New(),
+		}
+
+		err := s.usersRepo.UpsertUser(context.Background(), otherUser)
+		s.Require().NoError(err)
+
+		walletId := uuid.UUID(createdWallet.Id).String()
+		fullWalletPath := walletPath + "/" + walletId
+
+		s.sendHTTPRequest(http.MethodGet, fullWalletPath, http.StatusNotFound, nil, nil, otherUser)
+	})
+}
+
+func (s *IntegrationTestSuite) TestUpdateWallet() {
+	wallet := domain.Wallet{
+		Id: uuid.New(),
+		UserId: existingUser.Id.String(),
+		Name: "wallet 1",
+		Balance: 250.0,
+		Currency: "USD",
+	}
+
+	err := s.usersRepo.UpsertUser(context.Background(), existingUser)
+	s.Require().NoError(err)
+
+	var createdWallet domain.Wallet
+
+	s.sendHTTPRequest(http.MethodPost, walletPath, http.StatusCreated, &wallet, &createdWallet, existingUser)
+
+	s.Run("user not found", func() {
+		nonExistingUser := domain.User{
+			Id: uuid.New(),
+		}
+
+		s.sendHTTPRequest(http.MethodPatch, walletPath, http.StatusNotFound, nil, nil, nonExistingUser)
+	})
+
+	s.Run("wallet not found", func() {
+		walletId := uuid.New().String()
+		fullWalletPath := walletPath + "/" + walletId
+
+		s.sendHTTPRequest(http.MethodGet, fullWalletPath, http.StatusNotFound, nil, nil, existingUser)
+	})
+
+	s.Run("wallet updated successfully", func() {
+		updatedWallet := domain.Wallet{
+			Name: "Blue frog",
+		}
+
+		walletId := uuid.UUID(createdWallet.Id).String()
+		fullWalletPath := walletPath + "/" + walletId
+
+		s.sendHTTPRequest(http.MethodPatch, fullWalletPath, http.StatusOK, &updatedWallet, &createdWallet, existingUser)
+
+		s.Require().Equal(updatedWallet.Name, createdWallet.Name)
+	})
+
+	s.Run("wallet doesn't belong to the user", func() {
+		otherUser := domain.User{
+			Id: uuid.New(),
+		}
+
+		err := s.usersRepo.UpsertUser(context.Background(), otherUser)
+		s.Require().NoError(err)
+
+		walletId := uuid.UUID(createdWallet.Id).String()
+		fullWalletPath := walletPath + "/" + walletId
+
+		s.sendHTTPRequest(http.MethodGet, fullWalletPath, http.StatusNotFound, nil, nil, otherUser)
+	})
+}
+
+func (s *IntegrationTestSuite) TestDeleteWallet() {
+	wallet := domain.Wallet{
+		Id: uuid.New(),
+		UserId: existingUser.Id.String(),
+		Name: "wallet 1",
+		Balance: 300.0,
+		Currency: "USD",
+	}
+
+	err := s.usersRepo.UpsertUser(context.Background(), existingUser)
+	s.Require().NoError(err)
+
+	var createdWallet domain.Wallet
+
+	s.sendHTTPRequest(http.MethodPost, walletPath, http.StatusCreated, &wallet, &createdWallet, existingUser)
+
+	s.Run("user not found", func() {
+		nonExistingUser := domain.User{
+			Id: uuid.New(),
+		}
+
+		s.sendHTTPRequest(http.MethodGet, walletPath, http.StatusNotFound, nil, nil, nonExistingUser)
+	})
+
+	s.Run("wallet not found", func() {
+		walletId := uuid.New().String()
+		fullWalletPath := walletPath + "/" + walletId
+
+		s.sendHTTPRequest(http.MethodGet, fullWalletPath, http.StatusNotFound, nil, nil, existingUser)
+	})
+
+	s.Run("wallet successfully deleted", func() {
+		walletId := uuid.UUID(createdWallet.Id).String()
+		fullWalletPath := walletPath + "/" + walletId
+
+		s.sendHTTPRequest(http.MethodDelete, fullWalletPath, http.StatusNoContent, nil, nil, existingUser)
+	})
+
+	s.Run("wallet doesn't belong to the user", func() {
+		otherUser := domain.User{
+			Id: uuid.New(),
+		}
+
+		err := s.usersRepo.UpsertUser(context.Background(), otherUser)
+		s.Require().NoError(err)
+
+		walletId := uuid.UUID(createdWallet.Id).String()
+		fullWalletPath := walletPath + "/" + walletId
+
+		s.sendHTTPRequest(http.MethodGet, fullWalletPath, http.StatusNotFound, nil, nil, otherUser)
+	})
+}
+
+func (s *IntegrationTestSuite) TestGetWallets() {
+	err := s.usersRepo.UpsertUser(context.Background(), existingUser)
+	s.Require().NoError(err)
+
+	var arrWallets []domain.Wallet
+
+	wallet1 := domain.Wallet{
+		Id: uuid.New(),
+		UserId: existingUser.Id.String(),
+		Name: "wallet 1",
+		Balance: 100.0,
+		Currency: "USD",
+	}
+	
+	wallet2 := domain.Wallet{
+		Id: uuid.New(),
+		UserId: existingUser.Id.String(),
+		Name: "wallet 2",
+		Balance: 50.0,
+		Currency: "RUB",
+	}
+	
+	wallet3 := domain.Wallet{
+		Id: uuid.New(),
+		UserId: existingUser.Id.String(),
+		Name: "wallet 3",
+		Balance: 1000.0,
+		Currency: "USD",
+	}
+	
+	arrWallets = append(arrWallets, wallet1, wallet2, wallet3)
+
+	_, err = s.psql.Database().ExecContext(context.Background(),
+		`INSERT INTO wallets (name) VALUES ($1) WHERE id = $2 AND user_id = $3`,
+	wallet1.Name, wallet1.Id, wallet1.UserId)
+	s.Require().NoError(err)
+
+	_, err = s.psql.Database().ExecContext(context.Background(),
+		`INSERT INTO wallets (name) VALUES ($1) WHERE id = $2 AND user_id = $3`,
+	wallet2.Name, wallet2.Id, wallet2.UserId)
+	s.Require().NoError(err)
+
+	_, err = s.psql.Database().ExecContext(context.Background(),
+		`INSERT INTO wallets (name) VALUES ($1) WHERE id = $2 AND user_id = $3`,
+	wallet3.Name, wallet3.Id, wallet3.UserId)
+	s.Require().NoError(err)
+
+	var created1, created2, created3 domain.Wallet
+
+	s.sendHTTPRequest(http.MethodPost, walletPath, http.StatusCreated, &wallet1, &created1, existingUser)
+	s.sendHTTPRequest(http.MethodPost, walletPath, http.StatusCreated, &wallet2, &created2, existingUser)
+	s.sendHTTPRequest(http.MethodPost, walletPath, http.StatusCreated, &wallet3, &created3, existingUser)
+
+	s.Run("get successfully all wallets", func() {
+		var wallets []domain.Wallet
+
+		s.sendHTTPRequest(http.MethodGet, walletPath, http.StatusOK, nil, &wallets, existingUser)
+
+		s.Require().Len(wallets, len(arrWallets))
+	})
+
+	s.Run("user doesn't own any wallets", func() {
+		otherUser := domain.User{
+			Id: uuid.New(),
+		}
+
+		err := s.usersRepo.UpsertUser(context.Background(), otherUser)
+		s.Require().NoError(err)
+
+		var wallets []domain.Wallet
+
+		s.sendHTTPRequest(http.MethodGet, walletPath, http.StatusNotFound, nil, &wallets, otherUser)
+
+		s.Require().Len(wallets, 0)
+	})
+}


### PR DESCRIPTION
> make lint
go mod tidy
gofumpt -w .
gci write . --skip-generated -s standard -s default -s "prefix(lookaround.gitlab.yandexcloud.net/back/lookaround)"
2025-06-21T13:41:40.000+0300    INFO    gci/gci.go:47   Writing formatted File: cmd\users-producer\main.go
2025-06-21T13:41:40.000+0300    INFO    gci/gci.go:47   Writing formatted File: cmd\users-consumer\main.go
2025-06-21T13:41:40.004+0300    INFO    gci/gci.go:47   Writing formatted File: cmd\server\main.go
golangci-lint run ./...
cmd\users-producer\main.go:8:1: File is not properly formatted (gofumpt)

^
internal\transport\rest\server.go:7:1: File is not properly formatted (gofumpt)

^
internal\transport\rest\wallets.go:7:1: File is not properly formatted (gofumpt)

^
3 issues:
* gofumpt: 3
make: *** [Makefile:20: lint] Error 1

gofumpt is formatting the imports but then it swears that imports didn't formatted